### PR TITLE
Remove Docker healthcheck

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,1 +1,0 @@
-/users/sign_in Errbit

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,7 +27,7 @@ COPY ["vendor/", "/app/vendor/"]
 
 RUN apk add --no-cache --virtual build-dependencies build-base \
   && bundle config build.nokogiri --use-system-libraries \
-  && bundle config set without 'test development no_docker' \
+  && bundle config set without 'test development' \
   && bundle install -j "$(getconf _NPROCESSORS_ONLN)" --retry 5 \
   && bundle clean --force \
   && apk del build-dependencies
@@ -43,7 +43,5 @@ ENV RAILS_ENV=production
 ENV RAILS_SERVE_STATIC_FILES=true
 
 EXPOSE 3000/tcp
-
-HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):${PORT:-3000}/users/sign_in" || exit 1
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,9 @@ With few exceptions:
 5. `MAX_THREADS` env was removed. Use default rails `RAILS_MAX_THREADS` and `RAILS_MIN_THREADS`.
 6. Add `RAILS_LOG_LEVEL` env with default `info`.
 7. `RAILS_LOG_TO_STDOUT` env was drop without replacement. This is default behavior now.
+8. Add default rails health check at `/up`.
+9. Drop `/health/readiness` in favor `/up`.
+10. Drop `/health/liveness` in favor `/up`.
 
 Deprecations:
 

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,58 +1,10 @@
 # frozen_string_literal: true
 
 class HealthController < ActionController::Base
-  class << self
-    def impatient_mongoid_client
-      @impatient_mongoid_client ||= Mongo::Client.new(
-        Errbit::Config.mongo_url,
-        server_selection_timeout: 0.5,
-        connect_timeout: 0.5,
-        socket_timeout: 0.5
-      )
-    end
-
-    def clear_mongoid_client_cache
-      @impatient_mongoid_client = nil
-    end
-  end
-
-  def readiness
-    check_results = [run_mongo_check]
-    all_ok = check_results.all? do |check|
-      check[:ok]
-    end
-    response_status = all_ok ? :ok : :internal_server_error
-    render json: {ok: all_ok, details: check_results}, status: response_status
-  end
-
-  def liveness
-    render json: {ok: true}, status: :ok
-  end
-
   def api_key_tester
     app = App.where(api_key: params[:api_key]).first
     is_good_result = app ? true : false
     response_status = is_good_result ? :ok : :forbidden
     render json: {ok: is_good_result}, status: response_status
-  end
-
-  private
-
-  delegate :impatient_mongoid_client, :clear_mongoid_client_cache, to: :class
-
-  def run_mongo_check
-    # remember this client in a local variable so we can clear the cached
-    # client if it fails, but still always close the connection
-    local_mongoid_client = impatient_mongoid_client
-
-    # collections might be empty which is ok but it will raise an exception if
-    # database cannot be contacted
-    local_mongoid_client.collections
-    {check_name: "mongo", ok: true}
-  rescue => e
-    clear_mongoid_client_cache
-    {check_name: "mongo", ok: false, error_details: e.class.to_s}
-  ensure
-    local_mongoid_client.close
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up" => "rails/health#show", as: :rails_health_check
+
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
 
   # Hoptoad Notifier Routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,8 +66,6 @@ Rails.application.routes.draw do
 
   get "problems/:id" => "problems#show_by_id"
 
-  get "health/readiness" => "health#readiness"
-  get "health/liveness" => "health#liveness"
   get "health/api-key-tester" => "health#api_key_tester"
 
   namespace :api do

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe HealthController, type: :request do
-  let(:app) { Fabricate(:app, api_key: "APIKEY") }
+  let(:errbit_app) { Fabricate(:app, api_key: "APIKEY") }
 
   describe "api_key_tester" do
     it "will let you know when the api_key is not valid" do
@@ -14,7 +14,7 @@ RSpec.describe HealthController, type: :request do
     end
 
     it "can let you know that the api_key is valid" do
-      get "/health/api-key-tester?api_key=#{app.api_key}"
+      get "/health/api-key-tester?api_key=#{errbit_app.api_key}"
       expect(response).to be_successful
       parsed_response = response.parsed_body
       expect(parsed_response["ok"]).to eq true

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -3,40 +3,7 @@
 require "rails_helper"
 
 RSpec.describe HealthController, type: :request do
-  let(:errbit_app) { Fabricate(:app, api_key: "APIKEY") }
-
-  describe "readiness" do
-    before do
-      if HealthController.instance_variable_defined? :@impatient_mongoid_client
-        HealthController.remove_instance_variable :@impatient_mongoid_client
-      end
-    end
-
-    it "can let you know when the app is ready to receive requests" do
-      get "/health/readiness"
-      expect(response).to be_successful
-    end
-
-    it "can indicate if a check fails" do
-      expect(Errbit::Config).to receive(:mongo_url) {
-        "mongodb://localhost:27000"
-      }
-      get "/health/readiness"
-      expect(response).to be_server_error
-      parsed_response = response.parsed_body
-      expect(parsed_response["ok"]).to eq false
-      expect(parsed_response["details"].first["check_name"]).to eq "mongo"
-      expect(parsed_response["details"].first["ok"]).to eq false
-      expect(parsed_response["details"].first["error_details"]).to_not be_nil
-    end
-  end
-
-  describe "liveness" do
-    it "can let you know that the app is still alive" do
-      get "/health/liveness"
-      expect(response).to be_successful
-    end
-  end
+  let(:app) { Fabricate(:app, api_key: "APIKEY") }
 
   describe "api_key_tester" do
     it "will let you know when the api_key is not valid" do
@@ -47,7 +14,7 @@ RSpec.describe HealthController, type: :request do
     end
 
     it "can let you know that the api_key is valid" do
-      get "/health/api-key-tester?api_key=#{errbit_app.api_key}"
+      get "/health/api-key-tester?api_key=#{app.api_key}"
       expect(response).to be_successful
       parsed_response = response.parsed_body
       expect(parsed_response["ok"]).to eq true


### PR DESCRIPTION
Changes:

1. Remove Docker HEALTHCHECK
2. Add default rails health check at `/up`.
3. Drop `/health/readiness` in favor `/up`.
4. Drop `/health/liveness` in favor `/up`.

